### PR TITLE
Various changes made

### DIFF
--- a/src/Tasks/Create_Run_Experiments/index.ts
+++ b/src/Tasks/Create_Run_Experiments/index.ts
@@ -13,9 +13,8 @@ async function run() {
                 await EXP.createExperiment();
             }
         }
-        if (await RUN.runValidations()) {
-            if (RUN.createNewRun) {
-
+        if (RUN.createNewRun) {
+            if (await RUN.runValidations()) {
                 await RUN.createRun();
                 if (RUN.waitForRunToFinish == true) {
                     await RUN.monitorRun();

--- a/src/Tasks/Create_Run_Experiments/operations/Run.ts
+++ b/src/Tasks/Create_Run_Experiments/operations/Run.ts
@@ -34,14 +34,14 @@ export class Run {
     constructor() {
         this.endpointUrl = task.getInput('KubeflowEndpoint', true)!;
         this.runName = task.getInput('runName', false)!;
-        this.pipeline = task.getInput('pipeline', true)!;
-        this.useDefaultVersion = task.getBoolInput('useDefaultVersion', true)!;
+        this.pipeline = task.getInput('pipeline', false)!;
+        this.useDefaultVersion = task.getBoolInput('useDefaultVersion', false)!;
         this.createNewRun = task.getBoolInput('createNewRun', true);
         if (this.useDefaultVersion == true) {
             this.pipelineVersion = this.pipeline;
         }
         else {
-            this.pipelineVersion = task.getInput('pipelineVersion', true)!;
+            this.pipelineVersion = task.getInput('pipelineVersion', false)!;
         }
         this.pipelineParams = task.getInput('pipelineParams', false)!;
         this.description = task.getInput('runDescription', false)!;
@@ -338,7 +338,7 @@ export class Run {
 
     public async getPipelineVersionID(): Promise<string> {
         try {
-            var url = `${this.endpointUrl}${this.getAllVersionsEndpoint}?resource_key.type=PIPELINE&resource_key.id=${this.pipelineID}&filter={"predicates":[{"key":"name","op":"EQUALS","string_value":"${this.pipelineVersion}"}]}`;
+            var url = `${this.endpointUrl}${this.getAllVersionsEndpoint}?page_size=100&resource_key.type=PIPELINE_VERSION&resource_key.id=${this.pipelineID}&filter={"predicates":[{"key":"name","op":"EQUALS","string_value":"${this.pipelineVersion}"}]}`;
             url = encodeURI(url);
             var options: rest.IRequestOptions = { additionalHeaders: { 'authorization': `Bearer ${this.bearerToken}` } };
             var webRequest = await this.restAPIClient.get<IAllPipelineVersion>(url, options)!;
@@ -350,10 +350,10 @@ export class Run {
                             return versions[i].id;
                         }
                     }
-                    console.log('Version not found. Make sure your endpoint and/or bearer token are correct.');
+                    console.log('Pipeline version not found. Make sure your endpoint and/or bearer token are correct.');
                     return 'Not a valid version id.';
                 }
-                console.log('Version not found. Make sure your endpoint and/or bearer token are correct.');
+                console.log('Pipeline version not found. Make sure your endpoint and/or bearer token are correct.');
                 return 'Not a valid version id.';
             }
             console.log('Request did not go through. Make sure your endpoint and/or bearer token are correct.');

--- a/src/Tasks/Create_Run_Experiments/task.json
+++ b/src/Tasks/Create_Run_Experiments/task.json
@@ -56,25 +56,25 @@
             "type": "string",
             "label": "Pipeline Name",
             "defaultValue": "",
-            "required": true,
-            "helpMarkDown": "Kubeflow pipeline name.",
+            "required": false,
+            "helpMarkDown": "Kubeflow pipeline name. Only required if making a new run.",
             "groupName": "Pipeline"
         },
         {
             "name": "useDefaultVersion",
             "type": "boolean",
             "label": "Use Default Version",
-            "helpMarkDown": "If checked, will use the version name of the Kubeflow pipeline.",
+            "helpMarkDown": "If checked, will use the version name of the Kubeflow pipeline. Only required if making a new run.",
             "groupName": "Pipeline",
-            "required": true
+            "required": false
         },
         {
             "name": "pipelineVersion",
             "type": "string",
             "label": "Pipeline Version Name",
             "defaultValue": "",
-            "required": true,
-            "helpMarkDown": "Pipeline version name.",
+            "required": false,
+            "helpMarkDown": "Pipeline version name. Only required if making a new run.",
             "groupName": "Pipeline"
         },
         {


### PR DESCRIPTION
- Query for pipeline version updated to get up to 100 pipeline versions from one pipeline
- Errors that just mentioned version updated to say pipeline version
- On run task: pipeline, useDefaultVersion, and pipelineVersion inputs now optional since creating a new run is optional
- In run task index file, now checks if making a new run before running validations for the new run